### PR TITLE
Support JSON feeds, for partners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ etc/ubuntu-mirrors-rss.xml
 django-error.log
 node_modules/
 src/
+cache.sqlite

--- a/requirements/standard.txt
+++ b/requirements/standard.txt
@@ -1,4 +1,3 @@
-
 Django==1.9.6
 whitenoise==3.1
 django-yaml-redirects==0.4
@@ -7,7 +6,7 @@ django-versioned-static-url==0.1.1
 django-template-finder-view==0.2
 django-static-root-finder==0.3.1
 django-unslashed==0.3.0
-cachecontrol==0.11.6
 feedparser==5.2.1
 lockfile==0.12.2
 requests==2.10.0
+requests-cache==0.4.12

--- a/webapp/lib/feeds.py
+++ b/webapp/lib/feeds.py
@@ -1,35 +1,37 @@
 import feedparser
 import logging
-import requests
-from cachecontrol import CacheControlAdapter
-from cachecontrol.caches import FileCache
-from cachecontrol.heuristics import ExpiresAfter
+import json
+from requests_cache import CachedSession
+
 from django.conf import settings
 
 
 logger = logging.getLogger(__name__)
+requests_timeout = getattr(settings, 'FEED_TIMEOUT', 30)
+expiry_seconds = getattr(settings, 'FEED_EXPIRY', 300)
+
+cached_request = CachedSession(
+    expire_after=expiry_seconds,
+)
 
 
 def get_feed(feed_url):
     """
     Return feed parsed feed
     """
-    requests_timeout = getattr(settings, 'FEED_TIMOUT', 1)
 
-    cache_adapter = CacheControlAdapter(
-        cache=FileCache('.web_cache'),
-        heuristic=ExpiresAfter(hours=1),
-    )
-
-    session = requests.Session()
-    session.mount('http://', cache_adapter)
-    session.mount('https://', cache_adapter)
-
-    show_exceptions = getattr(settings, 'DEBUG', True)
-
-    feed_request = session.get(
+    response = cached_request.get(
         feed_url,
         timeout=requests_timeout
     )
 
-    return feedparser.parse(feed_request.text)
+    content_type = response.headers['Content-Type']
+
+    if 'rss' in content_type.lower():
+        content = feedparser.parse(response.text)
+    elif 'json' in content_type.lower():
+        content = json.loads(response.text)
+    else:
+        raise TypeError('Unknown content type: {}'.format(content_type))
+
+    return content


### PR DESCRIPTION
An attempt to help out with #912.
# Support JSON feeds

Use the content-type header to decide whether to decode the feed as JSON or RSS.
# Use requests-cache instead of CacheControl

CacheControl is a great library for manging caches based on HTTP headers from the response.
However, some of the feeds, especially the partners feed, don't provide any caching headers,
and so CacheControl won't cache them at all.

requests-cache conversely completely ignores HTTP caching headers and simply lets you set the timeout.

I think in the case of consuming feeds, this is probably a better model. We know how often we want our app making requests, and how fresh the feeds need to be.
We don't want the feed owner to be making that decision for us.
# Also
- Fix typo in `FEED_TIMEOUT` naming
- Set more sensible timeout default of 30 seconds
